### PR TITLE
Use verbose output from Fastly CLI

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -4,7 +4,7 @@ const exec = require('@actions/exec');
 const checkCLI = require('../util/cli');
 
 checkCLI().then(() => {
-  return exec.exec('fastly', ['compute', 'build'],  {
+  return exec.exec('fastly', ['compute', 'build', '-v'],  {
     cwd: core.getInput('project_directory')
   });
 }).catch((err) => {

--- a/deploy/index.js
+++ b/deploy/index.js
@@ -10,7 +10,7 @@ const projectDirectory = core.getInput('project_directory');
 const serviceId = core.getInput('service_id');
 
 checkCLI().then(async () => {
-  let params = ['compute', 'deploy'];
+  let params = ['compute', 'deploy', '-v'];
   if (serviceId !== 'default') params.push(['--service-id', serviceId]);
   const result = await exec.exec('fastly', params, {
     cwd: projectDirectory


### PR DESCRIPTION
This resolves the issue of the progress spinner filling up the logs.