### PR TITLE
Adds support for build: --skip-verification and deploy: --comment

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -15,3 +15,7 @@ inputs:
     description: 'Directory of the project to build, relative to the repository root.'
     required: false
     default: './'
+  skip_verification:
+    description: 'Skip verification steps and force build.'
+    required: false
+    default: false

--- a/build/index.js
+++ b/build/index.js
@@ -3,8 +3,12 @@ const exec = require('@actions/exec');
 
 const checkCLI = require('../util/cli');
 
+const skip_verification = core.getBooleanInput('skip_verification');
+
 checkCLI().then(() => {
-  return exec.exec('fastly', ['compute', 'build', '-v'],  {
+  let params = ['compute', 'build', '-v'];
+  if (skip_verification) params.push(['--skip-verification']);
+  return exec.exec('fastly', params,  {
     cwd: core.getInput('project_directory')
   });
 }).catch((err) => {

--- a/build/index.js
+++ b/build/index.js
@@ -7,7 +7,7 @@ const skip_verification = core.getBooleanInput('skip_verification');
 
 checkCLI().then(() => {
   let params = ['compute', 'build', '-v'];
-  if (skip_verification) params.push(['--skip-verification']);
+  if (skip_verification) params.push('--skip-verification');
   return exec.exec('fastly', params,  {
     cwd: core.getInput('project_directory')
   });

--- a/build/index.js
+++ b/build/index.js
@@ -3,11 +3,11 @@ const exec = require('@actions/exec');
 
 const checkCLI = require('../util/cli');
 
-const skip_verification = core.getBooleanInput('skip_verification');
+const skipVerification = core.getBooleanInput('skip_verification');
 
 checkCLI().then(() => {
   let params = ['compute', 'build', '-v'];
-  if (skip_verification) params.push('--skip-verification');
+  if (skipVerification) params.push('--skip-verification');
   return exec.exec('fastly', params,  {
     cwd: core.getInput('project_directory')
   });

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -19,3 +19,6 @@ inputs:
     description: 'The Fastly service ID to deploy to. Defaults to the value in fastly.toml'
     required: false
     default: 'default'
+  comment:
+    description: 'An optional comment to be included with the deploy.'
+    required: false

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -22,3 +22,4 @@ inputs:
   comment:
     description: 'An optional comment to be included with the deploy.'
     required: false
+    default: ''

--- a/deploy/index.js
+++ b/deploy/index.js
@@ -8,10 +8,12 @@ const checkCLI = require('../util/cli');
 
 const projectDirectory = core.getInput('project_directory');
 const serviceId = core.getInput('service_id');
+const comment = core.getInput('comment');
 
 checkCLI().then(async () => {
   let params = ['compute', 'deploy', '-v'];
   if (serviceId !== 'default') params.push(['--service-id=' + serviceId]);
+  if (comment) params.push(['--comment=' + comment]);
   const result = await exec.exec('fastly', params, {
     cwd: projectDirectory
   });

--- a/deploy/index.js
+++ b/deploy/index.js
@@ -12,8 +12,8 @@ const comment = core.getInput('comment');
 
 checkCLI().then(async () => {
   let params = ['compute', 'deploy', '-v'];
-  if (serviceId !== 'default') params.push(['--service-id=' + serviceId]);
-  if (comment) params.push(['--comment=' + comment]);
+  if (serviceId !== 'default') params.push('--service-id=' + serviceId);
+  if (comment) params.push('--comment=' + comment);
   const result = await exec.exec('fastly', params, {
     cwd: projectDirectory
   });


### PR DESCRIPTION
These are already arguments supported by the Fastly CLI. This just allows them to be set via the Github action. Related request: https://github.com/fastly/compute-actions/issues/6