### PR TITLE
Support new CLI OAuth flow

### DIFF
--- a/deploy/index.js
+++ b/deploy/index.js
@@ -12,7 +12,7 @@ const comment = core.getInput('comment');
 const verbose = core.getBooleanInput('verbose');
 
 checkCLI().then(async () => {
-  let params = ['compute', 'deploy'];
+  let params = ['compute', 'deploy', '--token', process.env['FASTLY_API_TOKEN']];
   if (serviceId !== 'default') params.push('--service-id=' + serviceId);
   if (verbose) params.push('--verbose');
   if (comment) params.push('--comment=' + comment);

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -12,6 +12,6 @@ runs:
 
 inputs:
   cli_version:
-    description: 'The version of the Fastly CLI to install, e.g. v0.20.0'
+    description: 'The version of the Fastly CLI to install, e.g. v1.0.0'
     required: false
     default: 'latest'


### PR DESCRIPTION
An upcoming CLI release will support OAuth ([PR](https://github.com/fastly/cli/pull/539)) and this will break user expectations as the OAuth flow requires user interaction. To continue to support automated environments like CI the `--token` flag is still supported and effectively _skips_ the OAuth flow.

**NOTE**: This PR should not be merged until the associated CLI release is published.