### PR TITLE
Provide default value for `viceroy_version` in main action manifest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'The version of the Fastly CLI to install, e.g. v0.20.0'
     required: false
     default: 'latest'
+  viceroy_version:
+    description: 'The version of Viceroy to install, e.g. v0.1.0'
+    required: false
+    default: 'latest'
   service_id:
     description: 'The Fastly service ID to deploy to. Defaults to the value in fastly.toml'
     required: false


### PR DESCRIPTION
Resolves #47 