### PR TITLE
Use new `@actions/artifact` API, resolves #60

### DIFF
--- a/deploy/index.js
+++ b/deploy/index.js
@@ -1,6 +1,6 @@
 const core = require('@actions/core');
 const exec = require('@actions/exec');
-const artifact = require('@actions/artifact');
+const { DefaultArtifactClient } = require("@actions/artifact");
 const glob = require('@actions/glob');
 const path = require('path');
 
@@ -37,6 +37,6 @@ async function uploadArtifact() {
 
   const artifactName = path.parse(files[0]).name;
 
-  const artifactClient = artifact.create();
+  const artifactClient = new DefaultArtifactClient();
   await artifactClient.uploadArtifact(artifactName, files, '.', {});
 }


### PR DESCRIPTION
I had failed to properly test the `deploy` action before releasing `v9`. This PR updates the action to use the new artifact upload interface.