### PR TITLE
fix: correct wrong branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You will need to install the correct Rust toolchain for the action to build your
 name: Deploy Application
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   deploy:
@@ -41,7 +41,7 @@ GitHub Action runners come with a node toolchain pre-installed, so you can just 
 name: Deploy Application
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   deploy:


### PR DESCRIPTION
This PR fixes branch names specified in the examples in the guide integration documentation. Now the branch name master is not the default branch name anymore, instead we have to use main. I confirmed the current sample doesn't work out of the box. (reference: https://github.com/github/renaming)