### PR TITLE
Update version number of actions/checkout in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Fastly CLI
       uses: fastly/compute-actions/setup@v11


### PR DESCRIPTION
This PR makes a minor update to the README.md file. It updates the version number of `action/checkout` in one of the examples.