### PR TITLE
Add staging sub-action for deploying to Fastly staging environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Alternatively, you can manually run the individual GitHub Actions for Compute if
 - [fastly/compute-actions/build](build/index.js) - Build a Compute project. Equivalent to `fastly compute build`
 - [fastly/compute-actions/deploy](deploy/index.js) - Deploy a Compute project. Equivalent to `fastly compute deploy`
 - [fastly/compute-actions/preview](preview/action.yml) - Deploy a Compute project to a new Fastly Service, which is deleted when the pull-request is merged or closed.
+- [fastly/compute-actions/staging](staging/action.yml) - Build and stage a Compute project to the Fastly staging environment without activating it.
 
 #### Deploy to Fastly when push to `main`
 
@@ -131,6 +132,32 @@ jobs:
         FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
 ```
 
+#### Stage to Fastly staging environment
+
+```yml
+name: Stage Application
+on:
+  push:
+    branches: [staging]
+
+jobs:
+  stage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Stage Compute Package
+      uses: fastly/compute-actions/staging@v12
+      with:
+        service_id: '4tYGx...' # optional, defaults to value in fastly.toml
+        comment: 'Staged via GitHub Actions' # optional
+      env:
+        FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
+```
+
 #### Preview on Fastly for each pull-request
 
 ```yml
@@ -160,8 +187,8 @@ The following inputs can be used as `with` keys for the actions in this reposito
 
 - `project_directory` - Directory of the project to deploy, relative to the repository root.
 - `cli_version` - The version of the Fastly CLI to install, e.g. v0.20.0
-- `service_id` - The Fastly service ID to deploy to. Defaults to the value in `fastly.toml`. (deploy only)
-- `comment` - An optional comment to be included with the deployed service version. (deploy only)
+- `service_id` - The Fastly service ID to deploy or stage to. Defaults to the value in `fastly.toml`. (deploy and staging)
+- `comment` - An optional comment to be included with the deployed or staged service version. (deploy and staging)
 - `version` - Version to clone from when deploying. Can be "latest", "active", or the number of a specific version. (deploy only)
 - `verbose` - Set to true to enable verbose logging.
 - `token` - The GitHub token to use when interacting with the GitHub API.

--- a/staging/action.yml
+++ b/staging/action.yml
@@ -12,8 +12,9 @@ inputs:
     required: false
     default: './'
   service_id:
-    description: 'The Fastly service ID to stage to.'
-    required: true
+    description: 'The Fastly service ID to stage to. Defaults to the value in fastly.toml.'
+    required: false
+    default: ''
   comment:
     description: 'An optional comment to be included with the staged service version.'
     required: false
@@ -34,7 +35,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Fastly CLI
-      uses: stackpop/fastly-compute-actions/setup@main
+      uses: fastly/compute-actions/setup@main
       with:
         token: ${{ inputs.token }}
         cli_version: ${{ inputs.cli_version }}
@@ -49,7 +50,11 @@ runs:
       env:
         FASTLY_API_TOKEN: ${{ env.FASTLY_API_TOKEN }}
       run: |
-        OUTPUT=$(fastly compute update --autoclone --service-id="${{ inputs.service_id }}" --version=active 2>&1 | tee /dev/stderr)
+        ARGS="--autoclone --version=active"
+        if [ -n "${{ inputs.service_id }}" ]; then
+          ARGS="$ARGS --service-id=${{ inputs.service_id }}"
+        fi
+        OUTPUT=$(fastly compute update $ARGS 2>&1 | tee /dev/stderr)
         VERSION=$(echo "$OUTPUT" | grep -oE 'version [0-9]+' | grep -oE '[0-9]+')
         if [ -z "$VERSION" ]; then
           echo "::error::Failed to extract version number from fastly compute update output"
@@ -65,18 +70,23 @@ runs:
       env:
         FASTLY_API_TOKEN: ${{ env.FASTLY_API_TOKEN }}
       run: |
-        fastly service-version update \
-          --version=${{ steps.upload-draft.outputs.version }} \
-          --service-id="${{ inputs.service_id }}" \
-          --comment="${{ inputs.comment }}"
+        ARGS="--version=${{ steps.upload-draft.outputs.version }} --comment=${{ inputs.comment }}"
+        if [ -n "${{ inputs.service_id }}" ]; then
+          ARGS="$ARGS --service-id=${{ inputs.service_id }}"
+        fi
+        fastly service-version update $ARGS
       shell: bash
+      working-directory: ${{ inputs.project_directory }}
 
     - name: Stage draft version
       env:
         FASTLY_API_TOKEN: ${{ env.FASTLY_API_TOKEN }}
       run: |
-        fastly service-version stage \
-          --version=${{ steps.upload-draft.outputs.version }} \
-          --service-id="${{ inputs.service_id }}"
+        ARGS="--version=${{ steps.upload-draft.outputs.version }}"
+        if [ -n "${{ inputs.service_id }}" ]; then
+          ARGS="$ARGS --service-id=${{ inputs.service_id }}"
+        fi
+        fastly service-version stage $ARGS
         echo "Successfully staged version ${{ steps.upload-draft.outputs.version }}"
       shell: bash
+      working-directory: ${{ inputs.project_directory }}

--- a/staging/action.yml
+++ b/staging/action.yml
@@ -1,0 +1,82 @@
+name: 'Stage a Compute package'
+author: 'Fastly'
+description: 'Builds and stages a Compute package to the Fastly staging environment using the Fastly CLI.'
+
+branding:
+  icon: 'upload-cloud'
+  color: 'red'
+
+inputs:
+  project_directory:
+    description: 'Directory of the project to build, relative to the repository root.'
+    required: false
+    default: './'
+  service_id:
+    description: 'The Fastly service ID to stage to.'
+    required: true
+  comment:
+    description: 'An optional comment to be included with the staged service version.'
+    required: false
+    default: ''
+  verbose:
+    description: 'Set to true to enable verbose logging'
+    required: false
+    default: 'false'
+  cli_version:
+    description: 'The version of the Fastly CLI to install, e.g. v0.20.0'
+    required: false
+    default: 'latest'
+  token:
+    description: 'The GitHub token to use when downloading the Fastly CLI'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Fastly CLI
+      uses: stackpop/fastly-compute-actions/setup@main
+      with:
+        token: ${{ inputs.token }}
+        cli_version: ${{ inputs.cli_version }}
+
+    - name: Build Compute package
+      run: fastly compute build --non-interactive
+      shell: bash
+      working-directory: ${{ inputs.project_directory }}
+
+    - name: Upload package as draft version
+      id: upload-draft
+      env:
+        FASTLY_API_TOKEN: ${{ env.FASTLY_API_TOKEN }}
+      run: |
+        OUTPUT=$(fastly compute update --autoclone --service-id="${{ inputs.service_id }}" --version=active 2>&1 | tee /dev/stderr)
+        VERSION=$(echo "$OUTPUT" | grep -oE 'version [0-9]+' | grep -oE '[0-9]+')
+        if [ -z "$VERSION" ]; then
+          echo "::error::Failed to extract version number from fastly compute update output"
+          exit 1
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Uploaded draft version: $VERSION"
+      shell: bash
+      working-directory: ${{ inputs.project_directory }}
+
+    - name: Add comment to draft version
+      if: ${{ inputs.comment != '' }}
+      env:
+        FASTLY_API_TOKEN: ${{ env.FASTLY_API_TOKEN }}
+      run: |
+        fastly service-version update \
+          --version=${{ steps.upload-draft.outputs.version }} \
+          --service-id="${{ inputs.service_id }}" \
+          --comment="${{ inputs.comment }}"
+      shell: bash
+
+    - name: Stage draft version
+      env:
+        FASTLY_API_TOKEN: ${{ env.FASTLY_API_TOKEN }}
+      run: |
+        fastly service-version stage \
+          --version=${{ steps.upload-draft.outputs.version }} \
+          --service-id="${{ inputs.service_id }}"
+        echo "Successfully staged version ${{ steps.upload-draft.outputs.version }}"
+      shell: bash


### PR DESCRIPTION
## Summary
- Adds a new `fastly/compute-actions/staging` composite action that builds and stages a Compute package to the Fastly staging environment without activating it
- The action creates a draft version via `fastly compute update --autoclone`, optionally adds a comment, then stages it with `fastly service-version stage`
- `service_id` is optional — defaults to the value in `fastly.toml`, consistent with the existing deploy action
- Updates README with staging documentation: sub-action listing, workflow example, and updated inputs table

## Test plan
- [x] Verify staging action works with explicit `service_id` input
- [x] Verify staging action works without `service_id` (falls back to `fastly.toml`)
- [x] Verify optional `comment` is applied to the staged version
- [x] Verify staging action installs CLI via setup sub-action
- [x] Confirm staged version is not activated in production