### PR TITLE
actions/checkout - update to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           - os: windows-2022
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Fastly CLI
         uses: ./setup


### PR DESCRIPTION
This addresses the 'Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: fastly/compute-actions' warning.