### PR TITLE
Upgrade used Node version to node24

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -7,7 +7,7 @@ branding:
   color: 'red'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 
 inputs:

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -7,7 +7,7 @@ branding:
   color: 'red'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 
 inputs:

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -7,7 +7,7 @@ branding:
   color: 'red'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 
 inputs:


### PR DESCRIPTION
The message in action runs changed to say that the runner was overriding the declared version and running against the newer version by default:

```
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

I'd assume that this not causing our pipelines any issues means that the newer NodeJS version works.

Closes #91 