### PR TITLE
Use absolute reference in composite action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,20 +43,20 @@ runs:
   using: composite
   steps:
     - name: Set up Fastly CLI
-      uses: ./setup
+      uses: fastly/compute-actions/setup@v14
       with:
         cli_version: ${{ inputs.cli_version }}
         viceroy_version: ${{ inputs.viceroy_version }}
         token: ${{ inputs.token }}
 
     - name: Build Compute package
-      uses: ./build
+      uses: fastly/compute-actions/build@v14
       with:
         project_directory: ${{ inputs.project_directory }}
         verbose: ${{ inputs.verbose }}
 
     - name: Deploy Compute package
-      uses: ./deploy
+      uses: fastly/compute-actions/deploy@v14
       with:
         project_directory: ${{ inputs.project_directory }}
         service_id: ${{ inputs.service_id }}


### PR DESCRIPTION
Users of the composite action will see:

>   Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
  '/home/runner/work/tech-summit-schedule-app/tech-summit-schedule-app/setup'. Did you forget to run actions/checkout before
  running your local action?

Caused by #93 introducing a relative reference, which the GHA runner tries to look up in the workspace rather than this repo.