### PR TITLE
Use self-repository references in composite action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,20 +43,20 @@ runs:
   using: composite
   steps:
     - name: Set up Fastly CLI
-      uses: fastly/compute-actions/setup@v14
+      uses: $/setup
       with:
         cli_version: ${{ inputs.cli_version }}
         viceroy_version: ${{ inputs.viceroy_version }}
         token: ${{ inputs.token }}
 
     - name: Build Compute package
-      uses: fastly/compute-actions/build@v14
+      uses: $/build
       with:
         project_directory: ${{ inputs.project_directory }}
         verbose: ${{ inputs.verbose }}
 
     - name: Deploy Compute package
-      uses: fastly/compute-actions/deploy@v14
+      uses: $/deploy
       with:
         project_directory: ${{ inputs.project_directory }}
         service_id: ${{ inputs.service_id }}


### PR DESCRIPTION
Using self-repository references avoids problems when repositories which use the composite action have the "pinned hash actions" policy in force.